### PR TITLE
Create a new async per middleware

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -13,8 +13,6 @@ function Instance(handlebars) {
   // by overriding this early in their apps
   var self = this;
 
-  self.async = async();
-
   self.handlebars = handlebars || require('handlebars').create();
 
   // cache for templates, express 3.x doesn't do this for us
@@ -32,6 +30,8 @@ function middleware(filename, options, cb) {
   var self = this;
   var cache = self.cache;
   var handlebars = self.handlebars;
+  
+  self.async = async();
 
   // grab extension from filename
   // if we need a layout, we will look for one matching out extension


### PR DESCRIPTION
Need to try and figure out a reproducible test case, but I'm having issues using with Express 4, with view caching on, and editing the template. Getting the `__async_ids__` sput out the first time after updating a template, trying to figure out why, but thought you might want to know. Somehow the `values` keys that come back to the @render_file/self.async.done callback don't match the ones in `res`. Will keep investigating, but again, this solves it for me. Thanks-