### PR TITLE
Fixing invalid check on undefined that can lead to bugs

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -100,14 +100,14 @@ function middleware(filename, options, cb) {
 
   // user did not specify a layout in the locals
   // check global layout state
-  if (layout === undefined && options.settings && options.settings['view options']) {
+  if (typeof layout === 'undefined' && options.settings && options.settings['view options']) {
     layout = options.settings['view options'].layout;
   }
 
   // user explicitly request no layout
   // either by specifying false for layout: false in locals
   // or by settings the false view options
-  if (layout !== undefined && !layout) {
+  if (typeof layout !== 'undefined' && !layout) {
     return render_file(options, cb);
   }
 


### PR DESCRIPTION
The correct way to check if a variable is not defined, in Javascript is: ```typeof layout === 'undefined'```. Doing something like ```layout === undefined``` doesn't check if a variable is undefined, it leverages the fact that there's typically no variable called "undefined"and compares layout to essentially null. It works sometimes, almost by accident but it's essentially a bug waiting to happen.