### PR TITLE
bump handlebars to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "handlebars": "2.0.0",
+    "handlebars": "3.0.0",
     "walk": "2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The 3.0.0 change is incredibly minimal and is more of a patch version. At quick glance, I think they merged a buch of 3.0.0 milestone stuff into 2.0.0 and they wanted to keep it consistent. Not sure though.

[3.0.0 release commits](https://github.com/wycats/handlebars.js/compare/v3.0.0...master)
[Milestone tracker](https://github.com/wycats/handlebars.js/issues?q=milestone%3A3.0)

I just like to keep things up to date. No biggie.

Oh, and it passes all the tests locally. Woot