### PR TITLE
Fix a bug where @data does not work in layouts

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -30,7 +30,7 @@ function middleware(filename, options, cb) {
   var self = this;
   var cache = self.cache;
   var handlebars = self.handlebars;
-  
+
   self.async = async();
 
   // grab extension from filename
@@ -59,7 +59,6 @@ function middleware(filename, options, cb) {
 
       try {
         var data = locals.__hbsLocals;
-        delete locals.__hbsLocals;
         var res = template(locals, { data: data });
         self.async.done(function(values) {
           Object.keys(values).forEach(function(id) {
@@ -85,7 +84,9 @@ function middleware(filename, options, cb) {
       var locals = options;
       locals.body = str;
 
-      var res = template(locals);
+      var data = locals.__hbsLocals;
+      delete locals.__hbsLocals;
+      var res = template(locals, { data: data });
       self.async.done(function(values) {
         Object.keys(values).forEach(function(id) {
           res = res.replace(id, values[id]);
@@ -115,7 +116,7 @@ function middleware(filename, options, cb) {
 
   var layout_filename = [].concat(view_dirs).map(function (view_dir) {
     var view_path = path.join(view_dir, layout || 'layout');
-    
+
     if (!path.extname(view_path)) {
       view_path += extension;
     }
@@ -170,7 +171,7 @@ function middleware(filename, options, cb) {
       }
 
       cacheAndCompile(str);
-    }); 
+    });
   }
 
   tryReadFileAndCache(layout_filename);

--- a/test/3.x/app.js
+++ b/test/3.x/app.js
@@ -50,6 +50,7 @@ hbs.registerPartials(__dirname + '/views/partials');
 
 // expose app and response locals in views
 hbs.localsAsTemplateData(app);
+app.locals.father = 'Alan';
 
 app.get('/', function(req, res){
   res.render('index', {
@@ -139,6 +140,13 @@ app.get('/locals', function(req, res) {
   });
 });
 
+app.get('/globals', function(req, res) {
+  res.render('globals', {
+    layout: 'layout_globals',
+    kids: [{ name: 'Jimmy' }, { name: 'Sally' }],
+  });
+});
+
 test('index', function(done) {
   var server = app.listen(3000, function() {
 
@@ -224,6 +232,22 @@ test('response locals', function(done) {
     var expected = fs.readFileSync(__dirname + '/../fixtures/locals.html', 'utf8');
 
     request('http://localhost:3000/locals', function(err, res, body) {
+      assert.equal(body, expected);
+      server.close();
+    });
+  });
+
+  server.on('close', function() {
+    done();
+  });
+});
+
+test('response globals', function(done) {
+  var server = app.listen(3000, function() {
+
+    var expected = fs.readFileSync(__dirname + '/../fixtures/globals.html', 'utf8');
+
+    request('http://localhost:3000/globals', function(err, res, body) {
       assert.equal(body, expected);
       server.close();
     });

--- a/test/3.x/views/globals.hbs
+++ b/test/3.x/views/globals.hbs
@@ -1,0 +1,3 @@
+{{#each kids}}
+{{@father}} has a kid named {{name}}.
+{{/each}}

--- a/test/3.x/views/layout_globals.hbs
+++ b/test/3.x/views/layout_globals.hbs
@@ -1,0 +1,3 @@
+{{@father}}'s Wonderful Kids
+
+{{{body}}}

--- a/test/4.x/app.js
+++ b/test/4.x/app.js
@@ -46,6 +46,7 @@ hbs.registerPartials(__dirname + '/views/partials');
 
 // expose app and response locals in views
 hbs.localsAsTemplateData(app);
+app.locals.father = 'Alan';
 
 app.get('/', function(req, res){
   res.render('index', {
@@ -135,10 +136,17 @@ app.get('/locals', function(req, res) {
   });
 });
 
+app.get('/globals', function(req, res) {
+  res.render('globals', {
+    layout: 'layout_globals',
+    kids: [{ name: 'Jimmy' }, { name: 'Sally' }],
+  });
+});
+
 app.get('/secondary', function(req, res) {
-  res.render('secondary', { 
-    text: '  index body :)', 
-    title: 'Express Handlebars Test' 
+  res.render('secondary', {
+    text: '  index body :)',
+    title: 'Express Handlebars Test'
   });
 });
 
@@ -232,6 +240,22 @@ test('response locals', function(done) {
     var expected = fs.readFileSync(__dirname + '/../fixtures/locals.html', 'utf8');
 
     request('http://localhost:3000/locals', function(err, res, body) {
+      assert.equal(body, expected);
+      server.close();
+    });
+  });
+
+  server.on('close', function() {
+    done();
+  });
+});
+
+test('response globals', function(done) {
+  var server = app.listen(3000, function() {
+
+    var expected = fs.readFileSync(__dirname + '/../fixtures/globals.html', 'utf8');
+
+    request('http://localhost:3000/globals', function(err, res, body) {
       assert.equal(body, expected);
       server.close();
     });

--- a/test/4.x/views/globals.hbs
+++ b/test/4.x/views/globals.hbs
@@ -1,0 +1,3 @@
+{{#each kids}}
+{{@father}} has a kid named {{name}}.
+{{/each}}

--- a/test/4.x/views/layout_globals.hbs
+++ b/test/4.x/views/layout_globals.hbs
@@ -1,0 +1,3 @@
+{{@father}}'s Wonderful Kids
+
+{{{body}}}

--- a/test/fixtures/globals.html
+++ b/test/fixtures/globals.html
@@ -1,0 +1,4 @@
+Alan's Wonderful Kids
+
+Alan has a kid named Jimmy.
+Alan has a kid named Sally.


### PR DESCRIPTION
When defining a local data through `app.locals` as follows:

    hbs.localsAsTemplateData(app);
    app.locals.foo = "bar";

the data `foo` can not be accessed as `{{@foo}}` in a layout.