### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "npm": "1.3.6",
     "request": "2.25.0"
   },
+  "license": "MIT",
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/