### PR TITLE
Add default partials directory

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -97,6 +97,14 @@ function middleware(filename, options, cb) {
     });
   }
 
+  // register default partials directory relative to the file
+  function registerDefaultPartials(done) {
+    var partials_dir = path.dirname(filename) + '/partials';
+    self.registerPartials(partials_dir, function() {
+      done()
+    });
+  }
+
   var layout = options.layout;
 
   // user did not specify a layout in the locals
@@ -109,7 +117,9 @@ function middleware(filename, options, cb) {
   // either by specifying false for layout: false in locals
   // or by settings the false view options
   if (layout !== undefined && !layout) {
-    return render_file(options, cb);
+    return registerDefaultPartials(function() {
+      render_file(options, cb);
+    });
   }
 
   var view_dirs = options.settings.views;
@@ -174,7 +184,9 @@ function middleware(filename, options, cb) {
     });
   }
 
-  tryReadFileAndCache(layout_filename);
+  registerDefaultPartials(function() {
+    tryReadFileAndCache(layout_filename);
+  });
 }
 
 // express 2.x template engine compliance

--- a/test/3.x/default_partials.js
+++ b/test/3.x/default_partials.js
@@ -1,0 +1,47 @@
+// builtin
+var fs = require('fs');
+var assert = require('assert');
+
+// 3rd party
+var express = require('express');
+var request = require('request');
+
+// local
+var hbs = require('../../').create();
+
+var app = express();
+
+// manually set render engine, under normal circumstances this
+// would not be needed as hbs would be installed through npm
+app.engine('hbs', hbs.__express);
+
+// set the view engine to use handlebars
+app.set('view engine', 'hbs');
+
+// manually set view directory to the default for these tests,
+// normally not needed unless a different directory is used
+app.set('views', __dirname + '/views');
+
+app.get('/partials', function(req, res) {
+  res.render('partials', { layout: false });
+});
+
+app.use(function(err, req, res, next) {
+  res.status(500).send(err.stack.toString());
+});
+
+test('default partials', function(done) {
+  var server = app.listen(3000, function() {
+
+    var expected = 'Test Partial 1Test Partial 2Test Partial 3';
+
+    request('http://localhost:3000/partials', function(err, res, body) {
+      assert.equal(body.trim(), expected.trim());
+      server.close();
+    });
+  });
+
+  server.on('close', function() {
+    done();
+  });
+});

--- a/test/3.x/index.js
+++ b/test/3.x/index.js
@@ -6,6 +6,7 @@ test('setup3.x', function(done) {
         npm.commands.install(['express@~3.16.8'], function() {
             // run tests
             require('./app');
+            require('./default_partials');
             require('./async_helpers');
             require('./view_engine');
             done();

--- a/test/4.x/default_partials.js
+++ b/test/4.x/default_partials.js
@@ -1,0 +1,47 @@
+// builtin
+var fs = require('fs');
+var assert = require('assert');
+
+// 3rd party
+var express = require('express');
+var request = require('request');
+
+// local
+var hbs = require('../../').create();
+
+var app = express();
+
+// manually set render engine, under normal circumstances this
+// would not be needed as hbs would be installed through npm
+app.engine('hbs', hbs.__express);
+
+// set the view engine to use handlebars
+app.set('view engine', 'hbs');
+
+// manually set view directory to the default for these tests,
+// normally not needed unless a different directory is used
+app.set('views', __dirname + '/views');
+
+app.get('/partials', function(req, res) {
+  res.render('partials', { layout: false });
+});
+
+app.use(function(err, req, res, next) {
+  res.status(500).send(err.stack.toString());
+});
+
+test('default partials', function(done) {
+  var server = app.listen(3000, function() {
+
+    var expected = 'Test Partial 1Test Partial 2Test Partial 3';
+
+    request('http://localhost:3000/partials', function(err, res, body) {
+      assert.equal(body.trim(), expected.trim());
+      server.close();
+    });
+  });
+
+  server.on('close', function() {
+    done();
+  });
+});

--- a/test/4.x/index.js
+++ b/test/4.x/index.js
@@ -9,6 +9,7 @@ test('setup4.x', function(done) {
             }
             // run tests
             require('./app');
+            require('./default_partials');
             require('./async_helpers');
             require('./view_engine');
             done();


### PR DESCRIPTION
This PR automatically registers partials in a default directory relative to a view directory.

For example: if a view directory is `app/views`, then partials in `app/views/partials` are automatically registered. 

Eliminates the need to explicitly set `hbs.registerPartials('views/partials')`, matching Express defaults. Also works with multiple view directories, ie: `app.set('views', ['templates', 'pages'])`.

For small apps, it's possible to not have to interact with hbs at all: 
```javascript 
// server.js
var express = require('express')
var server  = express()

server.set('view engine', 'hbs')

server.get('/', function(req, res) {
  res.render('index')
})

server.listen(3000)

// views/index.hbs
<h1>Hello {{> name}}</h1>

// views/partials/name.hbs
<i>Zach</i>

$ curl http://localhost:3000/
<h1>Hello <i>Zach</i></h1>
```

Manually setting the partials directory is still allowed via `hbs.registerPartials()`. This just enables a common default.

I can update docs/examples as needed.