### PR TITLE
Update handlebars version spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "handlebars": "3.0.0",
+    "handlebars": "^3.0.0",
     "walk": "2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Modify the handlebars version spec to allow for non-major version
updates (that should be API compatible), so bugfix releases can be
picked up without issue.

Fixes https://github.com/donpark/hbs/issues/99