### PR TITLE
Fix tests on Windows: use correct path separators

### DIFF
--- a/test/3.x/app.js
+++ b/test/3.x/app.js
@@ -1,5 +1,6 @@
 // builtin
 var fs = require('fs');
+var path = require('path');
 var assert = require('assert');
 
 // 3rd party
@@ -200,7 +201,7 @@ test('syntax error', function(done) {
 
     request('http://localhost:3000/syntax-error', function(err, res, body) {
       assert.equal(res.statusCode, 500);
-      assert.equal(body.split('\n')[0], 'Error: ' + __dirname + '/views/syntax-error.hbs: Parse error on line 1:');
+      assert.equal(body.split('\n')[0], 'Error: ' + __dirname + path.sep + 'views' + path.sep + 'syntax-error.hbs: Parse error on line 1:');
       server.close();
     });
   });

--- a/test/4.x/app.js
+++ b/test/4.x/app.js
@@ -1,5 +1,6 @@
 // builtin
 var fs = require('fs');
+var path = require('path');
 var assert = require('assert');
 
 // 3rd party
@@ -207,7 +208,7 @@ test('syntax error', function(done) {
 
     request('http://localhost:3000/syntax-error', function(err, res, body) {
       assert.equal(res.statusCode, 500);
-      assert.equal(body.split('\n')[0], 'Error: ' + __dirname + '/views/syntax-error.hbs: Parse error on line 1:');
+      assert.equal(body.split('\n')[0], 'Error: ' + __dirname + path.sep + 'views' + path.sep + 'syntax-error.hbs: Parse error on line 1:');
       //assert.equal(bod);
       server.close();
     });


### PR DESCRIPTION
Windows and other OSes use different path separators; that needs to be
taken into account when testing error messages that include paths.