### PR TITLE
Fix localsAsTemplateData when caching is enabled

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -37,13 +37,16 @@ function middleware(filename, options, cb) {
   // if we need a layout, we will look for one matching out extension
   var extension = path.extname(filename);
 
+  // If passing the locals as data, create the handlebars options object now
+  var handlebarsOpts = (self.__localsAsData) ? { data: options._locals } : undefined;
+
   // render the original file
   // cb(err, str)
   function render_file(locals, cb) {
     // cached?
     var template = cache[filename];
     if (template) {
-      return cb(null, template(locals));
+      return cb(null, template(locals, handlebarsOpts));
     }
 
     fs.readFile(filename, 'utf8', function(err, str){
@@ -51,15 +54,13 @@ function middleware(filename, options, cb) {
         return cb(err);
       }
 
-      var locals = options;
       var template = handlebars.compile(str);
-      if (options.cache) {
+      if (locals.cache) {
         cache[filename] = template;
       }
 
       try {
-        var data = locals.__hbsLocals;
-        var res = template(locals, { data: data });
+        var res = template(locals, handlebarsOpts);
         self.async.done(function(values) {
           Object.keys(values).forEach(function(id) {
             res = res.replace(id, values[id]);
@@ -81,12 +82,9 @@ function middleware(filename, options, cb) {
         return cb(err);
       }
 
-      var locals = options;
       locals.body = str;
 
-      var data = locals.__hbsLocals;
-      delete locals.__hbsLocals;
-      var res = template(locals, { data: data });
+      var res = template(locals, handlebarsOpts);
       self.async.done(function(values) {
         Object.keys(values).forEach(function(id) {
           res = res.replace(id, values[id]);
@@ -237,6 +235,9 @@ Instance.prototype.registerAsyncHelper = function(name, fn) {
 };
 
 Instance.prototype.localsAsTemplateData = function(app) {
+  // Set a flag to indicate we should pass locals as data
+  this.__localsAsData = true;
+
   app.render = (function(render) {
     return function(view, options, callback) {
       if (typeof options === "function") {
@@ -249,10 +250,6 @@ Instance.prototype.localsAsTemplateData = function(app) {
       for (var key in this.locals) {
         options._locals[key] = this.locals[key];
       }
-
-      // Store the data again, so that we can differentiate this data from
-      // the data passed to response.data() when we're inside the view
-      options._locals.__hbsLocals = options._locals;
 
       return render.call(this, view, options, callback);
     };

--- a/test/3.x/app.js
+++ b/test/3.x/app.js
@@ -140,6 +140,15 @@ app.get('/locals', function(req, res) {
   });
 });
 
+app.get('/locals-cached', function(req, res) {
+  res.locals.person = 'Alan';
+  res.render('locals', {
+    layout: false,
+    cache: true,
+    kids: [{ name: 'Jimmy' }, { name: 'Sally' }],
+  });
+});
+
 app.get('/globals', function(req, res) {
   res.render('globals', {
     layout: 'layout_globals',
@@ -234,6 +243,27 @@ test('response locals', function(done) {
     request('http://localhost:3000/locals', function(err, res, body) {
       assert.equal(body, expected);
       server.close();
+    });
+  });
+
+  server.on('close', function() {
+    done();
+  });
+});
+
+test('response locals cached', function(done) {
+  var server = app.listen(3000, function() {
+
+    var expected = fs.readFileSync(__dirname + '/../fixtures/locals.html', 'utf8');
+
+    request('http://localhost:3000/locals-cached', function(err, res, body) {
+      assert.equal(body, expected);
+
+      // Request the second time, so it is cached
+      request('http://localhost:3000/locals-cached', function(err, res, body) {
+        assert.equal(body, expected);
+        server.close();
+      });
     });
   });
 

--- a/test/4.x/app.js
+++ b/test/4.x/app.js
@@ -136,6 +136,15 @@ app.get('/locals', function(req, res) {
   });
 });
 
+app.get('/locals-cached', function(req, res) {
+  res.locals.person = 'Alan';
+  res.render('locals', {
+    layout: false,
+    cache: true,
+    kids: [{ name: 'Jimmy' }, { name: 'Sally' }],
+  });
+});
+
 app.get('/globals', function(req, res) {
   res.render('globals', {
     layout: 'layout_globals',
@@ -242,6 +251,27 @@ test('response locals', function(done) {
     request('http://localhost:3000/locals', function(err, res, body) {
       assert.equal(body, expected);
       server.close();
+    });
+  });
+
+  server.on('close', function() {
+    done();
+  });
+});
+
+test('response locals cached', function(done) {
+  var server = app.listen(3000, function() {
+
+    var expected = fs.readFileSync(__dirname + '/../fixtures/locals.html', 'utf8');
+
+    request('http://localhost:3000/locals-cached', function(err, res, body) {
+      assert.equal(body, expected);
+
+      // Request the second time, so it is cached
+      request('http://localhost:3000/locals-cached', function(err, res, body) {
+        assert.equal(body, expected);
+        server.close();
+      });
     });
   });
 


### PR DESCRIPTION
When a template is rendered from the cache, the extra options object
(containing the data property) isn't being passed in to the render
function. Thus, any functionality that depends on this will fail.

The code has been refactored to create a single handlebars options
object for each (main) template render, which is then passed in all
scenarios (cache, template, layout template).

The code also cleans up the use of parent-scope variables for the render
context, and avoids a circular reference to the "_locals" object from
itself in favor of an instance-based boolean to determine whether the
locals should be passed as template data.

Tests have also been added to test for this scenario.

fixes https://github.com/donpark/hbs/issues/101