### PR TITLE
Upgrade to walk@2.3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "handlebars": "4.0.3",
-    "walk": "2.2.1"
+    "walk": "2.3.9"
   },
   "devDependencies": {
     "mocha": "1.6.0",


### PR DESCRIPTION
`walk@2.2.1` still uses an old `foreachasync` version, which isn't avaiable anymore on npm.
This got fixed in `walk@2.3.9`

Without this update, `npm install hbs` fails.