### PR TITLE
Replace async IDs on resolving async helpers

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -46,7 +46,8 @@ function middleware(filename, options, cb) {
     // cached?
     var template = cache[filename];
     if (template) {
-      return cb(null, template(locals, handlebarsOpts));
+      var res = template(locals, handlebarsOpts);
+      return replace_async_helpers(res, cb);
     }
 
     fs.readFile(filename, 'utf8', function(err, str){
@@ -59,20 +60,24 @@ function middleware(filename, options, cb) {
         cache[filename] = template;
       }
 
-      try {
-        var res = template(locals, handlebarsOpts);
-        self.async.done(function(values) {
-          Object.keys(values).forEach(function(id) {
-            res = res.replace(id, values[id]);
-          });
-
-          cb(null, res);
-        });
-      } catch (err) {
-        err.message = filename + ': ' + err.message;
-        cb(err);
-      }
+      var res = template(locals, handlebarsOpts);
+      return replace_async_helpers(res, cb);
     });
+  }
+
+  // replace async helper ids
+  function replace_async_helpers(res, cb) {
+    try {
+      self.async.done(function(values) {
+        Object.keys(values).forEach(function(id) {
+          res = res.replace(id, values[id]);
+        });
+        cb(null, res);
+      });
+    } catch (err) {
+      err.message = filename + ': ' + err.message;
+      cb(err);
+    }
   }
 
   // render with a layout


### PR DESCRIPTION
This pull request fixes #67 where async helper IDs do not get replaced after being cached.