### PR TITLE
Upgrades handlebars to 4.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "handlebars": "4.0.3",
+    "handlebars": "^4.0.5",
     "walk": "2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Handlebars 4.0.3 has a vulnerable dependency (found with `nsp check`):

```
(+) 1 vulnerabilities found
┌───────────────┬───────────────────────────────────────────────────────┐
│               │ Regular Expression Denial of Service                  │
├───────────────┼───────────────────────────────────────────────────────┤
│ Name          │ uglify-js                                             │
├───────────────┼───────────────────────────────────────────────────────┤
│ Installed     │ 2.4.24                                                │
├───────────────┼───────────────────────────────────────────────────────┤
│ Vulnerable    │ <2.6.0                                                │
├───────────────┼───────────────────────────────────────────────────────┤
│ Patched       │ >=2.6.0                                               │
├───────────────┼───────────────────────────────────────────────────────┤
│ Path          │ hbs@4.0.0 > handlebars@4.0.3 > uglify-js@2.4.24       │
├───────────────┼───────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/48                 │
└───────────────┴───────────────────────────────────────────────────────┘
```

If we upgrade to 4.0.5, it fixes this issue

```
(+) No known vulnerabilities found
```